### PR TITLE
needed to run as sudoer in order to enable apt lock for exclusive operation

### DIFF
--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -3,6 +3,7 @@
 # Debian OS family install tasks
 
 - name: 'INSTALL | APT | Install openjdk-jdk'
+  sudo: yes
   apt:
     name: "{{ item.name }}"
     state: "{{ item.state | default('present') }}"


### PR DESCRIPTION
issue found on Ubuntu 19.04 with ansible 2.7.8 and python 3.7.3